### PR TITLE
Parse mkv files for SegmentUID and Duration without MKVToolNix

### DIFF
--- a/vfr.py
+++ b/vfr.py
@@ -15,6 +15,10 @@ default_fps = "30000/1001"
 # Change the paths here if the programs aren't in your $PATH
 mkvmerge = r'mkvmerge'
 
+# Check to utilize mkvtoolnix for obtaining the uid and duration of the mkv 
+# files specified on templates, instead of letting this script parse them 
+# directly (faster).  Just in case the later fails.
+parse_with_mkvinfo = False
 
 def main(args):
     from optparse import OptionParser


### PR DESCRIPTION
- Eliminates the dependency on MKVToolNix if audio trimming is not required. Not that I really expect someone to work with mkv files and not use it.
- About 700x faster parsing, very noticeable on directories with a large number 
  of mkv files.

This is something I did just for fun, the speed improvement was a nice surprise. The Matroska files are not parsed properly, instead the needed elements are just directly searched for in the file. It works correctly on every mkv file I tried, from different muxers, but just in case there's also a new option on the first lines of vfr.py for using mkvinfo again.
